### PR TITLE
new lib_mail.sh

### DIFF
--- a/scripts/camera-backup.sh
+++ b/scripts/camera-backup.sh
@@ -22,6 +22,9 @@ CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
+# Load Mail library
+. "${CONFIG_DIR}/lib-mail.sh"
+
 # Load LCD library
 . "${CONFIG_DIR}/lib-lcd.sh"
 
@@ -63,12 +66,7 @@ fi
 # Check internet connection and send
 # a notification if the NOTIFY option is enabled
 check=$(wget -q --spider http://google.com/)
-if [ $NOTIFY = true ] || [ ! -z "$check" ]; then
-    curl --url 'smtps://'$SMTP_SERVER':'$SMTP_PORT --ssl-reqd \
-        --mail-from $MAIL_USER \
-        --mail-rcpt $MAIL_TO \
-        --user $MAIL_USER':'$MAIL_PASSWORD \
-        -T <(echo -e 'From: '$MAIL_USER'\nTo: '$MAIL_TO'\nSubject: Little Backup Box\n\nBackup complete.')
+    send_email "Little Backup Box" "Backup complete."
 fi
 
 # Power off

--- a/scripts/config.cfg
+++ b/scripts/config.cfg
@@ -14,3 +14,4 @@ SMTP_PORT=""
 MAIL_USER=""
 MAIL_PASSWORD=""
 MAIL_TO=""
+MAIL_HTML="true" # Set to false to disable HTML-Mails

--- a/scripts/internal-backup.sh
+++ b/scripts/internal-backup.sh
@@ -22,6 +22,9 @@ CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
+# Load Mail library
+. "${CONFIG_DIR}/lib-mail.sh"
+
 # Load LCD library
 . "${CONFIG_DIR}/lib-lcd.sh"
 
@@ -100,11 +103,7 @@ fi
 # a notification if the NOTIFY option is enabled
 check=$(wget -q --spider http://google.com/)
 if [ $NOTIFY = true ] || [ ! -z "$check" ]; then
-	curl --url 'smtps://'$SMTP_SERVER':'$SMTP_PORT --ssl-reqd \
-		--mail-from $MAIL_USER \
-		--mail-rcpt $MAIL_TO \
-		--user $MAIL_USER':'$MAIL_PASSWORD \
-		-T <(echo -e "From: ${MAIL_USER}\nTo: ${MAIL_TO}\nSubject: Little Backup Box: Backup complete\n\nBackup log:\n\n${RSYNC_OUTPUT}")
+	send_email "Little Backup Box: Backup complete" "Backup log:\n\n${RSYNC_OUTPUT}"
 fi
 
 # Power off

--- a/scripts/ip.sh
+++ b/scripts/ip.sh
@@ -22,6 +22,9 @@ CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
+# Load Mail library
+. "${CONFIG_DIR}/lib-mail.sh"
+
 ping -c1 google.com &>/dev/null
 while [ $? != 0 ]; do
     sleep 10
@@ -30,9 +33,5 @@ done
 
 if [ ! -z $SMTP_SERVER ]; then
     IP=$(hostname -I | cut -d' ' -f1)
-    curl --url 'smtps://'$SMTP_SERVER':'$SMTP_PORT --ssl-reqd \
-        --mail-from $MAIL_USER \
-        --mail-rcpt $MAIL_TO \
-        --user $MAIL_USER':'$MAIL_PASSWORD \
-        -T <(echo -e 'From: '$MAIL_USER'\nTo: '$MAIL_TO'\nSubject: Little Backup Box: IP '$IP'\n\n'$IP'\n')
+    send_email "Little Backup Box: IP $IP" "$IP" "<a href='http://${IP}:8000'>Little Backup Box Web-UI: http://${IP}:8000</a>"
 fi

--- a/scripts/lib-mail.sh
+++ b/scripts/lib-mail.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Author: Dmitri Popov, dmpop@linux.com
+
+#######################################################################
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
+function send_email () {
+
+# Takes up to 3 arguments:
+# sendmail "$Subject" "$Text_plain" "$Text_HTML (optional)"
+
+    # Arguments
+    SUBJECT=$1
+    TEXT_PLAIN=$2
+    TEXT_HTML=$3
+
+    # Config
+    CONFIG_DIR=$(dirname "$0")
+    CONFIG="${CONFIG_DIR}/config.cfg"
+    dos2unix "$CONFIG"
+    source "$CONFIG"
+
+    BOUNDARY="${RANDOM}${RANDOM}${RANDOM}"
+    TEXT=""
+    
+    #Mail-body
+    if [ "${MAIL_HTML}" = "true" ];
+    then
+        TEXT="Content-Type: multipart/alternative;boundary=${BOUNDARY}\n\n$TEXT_PLAIN\n\n--${BOUNDARY}\nContent-type: text/html;charset=utf-8\n\n$TEXT_HTML\n\n--${BOUNDARY}--"
+    else
+        TEXT="\n\n$TEXT_PLAIN\n\n"
+    fi
+    
+    # Check internet connection and send
+    # a notification if the NOTIFY option is enabled
+    check=$(wget -q --spider http://google.com/)
+    if [ $NOTIFY = true ] || [ ! -z "$check" ]; then
+        curl --url 'smtps://'$SMTP_SERVER':'$SMTP_PORT --ssl-reqd \
+            --mail-from $MAIL_USER \
+            --mail-rcpt $MAIL_TO \
+            --user $MAIL_USER':'$MAIL_PASSWORD \
+            -T <(echo -e "From: ${MAIL_USER}\nTo: ${MAIL_TO}\nSubject: ${SUBJECT}\n${TEXT}")
+    fi
+}

--- a/scripts/source-backup.sh
+++ b/scripts/source-backup.sh
@@ -25,6 +25,9 @@ source "$CONFIG"
 # Configuration
 FILE_OLED_OLD="/root/oled_old.txt"
 
+# Load Mail library
+. "${CONFIG_DIR}/lib-mail.sh"
+
 # Load LCD library
 . "${CONFIG_DIR}/lib-lcd.sh"
 
@@ -118,11 +121,7 @@ kill $PID
 # a notification if the NOTIFY option is enabled
 check=$(wget -q --spider http://google.com/)
 if [ $NOTIFY = true ] || [ ! -z "$check" ]; then
-	curl --url 'smtps://'$SMTP_SERVER':'$SMTP_PORT --ssl-reqd \
-		--mail-from $MAIL_USER \
-		--mail-rcpt $MAIL_TO \
-		--user $MAIL_USER':'$MAIL_PASSWORD \
-	-T <(echo -e "From: ${MAIL_USER}\nTo: ${MAIL_TO}\nSubject: Little Backup Box: Backup complete\n\nBackup log:\n\n${RSYNC_OUTPUT}")
+	send_email "Little Backup Box: Backup complete" "Backup log:\n\n${RSYNC_OUTPUT}"
 fi
 
 # Power off


### PR DESCRIPTION
Mails are sent by function send_email in lib-mail.sh. The function send_email takes up to three arguments: subject, plain-text, html-text
If in config.cfg enabled, ip.sh sends a HTML-Link.