### PR TITLE
Stabilize working dir recognition

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -23,8 +23,8 @@
 # To extend, just use the elif-section-examples
 ###############################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
@@ -53,13 +53,13 @@ fi
 # END
 
 # Load Mail library
-. "${CONFIG_DIR}/lib-mail.sh"
+. "${WORKING_DIR}/lib-mail.sh"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 # Load Log library
-. "${CONFIG_DIR}/lib-log.sh"
+. "${WORKING_DIR}/lib-log.sh"
 
 # Overwrite logfile
 log_to_file "Source: ${SOURCE_MODE}"
@@ -256,7 +256,7 @@ if [ $DISP = true ]; then
 
     # END
 
-    source "${CONFIG_DIR}/status-display.sh" "${FILES_TO_SYNC}" "${BACKUP_PATH}" &
+    source "${WORKING_DIR}/status-display.sh" "${FILES_TO_SYNC}" "${BACKUP_PATH}" &
     PID=$!
 fi
 
@@ -315,4 +315,4 @@ if [ $NOTIFY = true ] || [ ! -z "$check" ]; then
 fi
 
 # Power off
-source "${CONFIG_DIR}/poweroff.sh"
+source "${WORKING_DIR}/poweroff.sh"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -23,7 +23,7 @@
 # To extend, just use the elif-section-examples
 ###############################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
@@ -264,7 +264,7 @@ fi
 # RUN BACKUP #
 ##############
 
-# START 
+# START
 
 # To define a new method, add an elif block (example below)
 

--- a/scripts/change-mode.sh
+++ b/scripts/change-mode.sh
@@ -23,7 +23,7 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 source "$CONFIG"
 

--- a/scripts/change-mode.sh
+++ b/scripts/change-mode.sh
@@ -23,8 +23,8 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 source "$CONFIG"
 
 BACKTITLE="Little Backup Box"

--- a/scripts/custom1.sh
+++ b/scripts/custom1.sh
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 message="Custom action 1 works!"
 

--- a/scripts/custom1.sh
+++ b/scripts/custom1.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/custom2.sh
+++ b/scripts/custom2.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/custom2.sh
+++ b/scripts/custom2.sh
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 message="Custom action 2 works!"
 

--- a/scripts/custom3.sh
+++ b/scripts/custom3.sh
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 message="Custom action 3 works!"
 

--- a/scripts/custom3.sh
+++ b/scripts/custom3.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/ios-backup.sh
+++ b/scripts/ios-backup.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 sudo dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/ios-backup.sh
+++ b/scripts/ios-backup.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 sudo dos2unix "$CONFIG"
 source "$CONFIG"
 
@@ -26,10 +26,10 @@ source "$CONFIG"
 FILE_OLED_OLD="/root/oled_old.txt"
 
 # Load Mail library
-. "${CONFIG_DIR}/lib-mail.sh"
+. "${WORKING_DIR}/lib-mail.sh"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 # Set the ACT LED to heartbeat
 sudo sh -c "echo heartbeat > /sys/class/leds/led0/trigger"
@@ -84,7 +84,7 @@ if [ $DISP = true ]; then
 	# Get number of files to sync
 	FILES_TO_SYNC=$(rsync -avh --stats --dry-run "$SOURCE_DIR"/ "${STORAGE_MOUNT_POINT}/iOS" | awk '{for(i=1;i<=NF;i++)if ($i " " $(i+1) " " $(i+2) " " $(i+3)=="Number of created files:"){print $(i+4)}}' | sed s/,//g)
 
-	source "${CONFIG_DIR}/status-display.sh" "${FILES_TO_SYNC}" "${STORAGE_MOUNT_POINT}/iOS" &
+	source "${WORKING_DIR}/status-display.sh" "${FILES_TO_SYNC}" "${STORAGE_MOUNT_POINT}/iOS" &
 	PID=$!
 fi
 
@@ -114,4 +114,4 @@ fi
 sudo umount $MOUNT_IOS_DIR
 
 # Power off
-source "${CONFIG_DIR}/poweroff.sh"
+source "${WORKING_DIR}/poweroff.sh"

--- a/scripts/ip.sh
+++ b/scripts/ip.sh
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Load Mail library
-. "${CONFIG_DIR}/lib-mail.sh"
+. "${WORKING_DIR}/lib-mail.sh"
 
 ping -c1 google.com &>/dev/null
 while [ $? != 0 ]; do

--- a/scripts/ip.sh
+++ b/scripts/ip.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/lib-lcd.sh
+++ b/scripts/lib-lcd.sh
@@ -26,9 +26,9 @@ function lcd_message () {
     #Arguments:
     LineCount=$#
     Lines=( "$@" )
-    
+
     # Load LOG library
-    . "${CONFIG_DIR}/lib-log.sh"
+    . "${WORKING_DIR}/lib-log.sh"
 
     #Config
     FILE_OLED_OLD="/root/oled_old.txt"
@@ -59,7 +59,7 @@ function lcd_message () {
             n=$(expr $n + 1)
         done
     fi
-    
+
     #fifo display
     if [ -f "${FILE_OLED_OLD}" ]; then
         readarray -t OLED_OLD < "${FILE_OLED_OLD}"
@@ -76,19 +76,19 @@ function lcd_message () {
     echo -en "${Lines[0]}\n${Lines[1]}\n${Lines[2]}\n${Lines[3]}" > "${FILE_OLED_OLD}"
 
     #display
-    
+
     LogLines=""
     n=0
-    
+
     oled r
     while [ "${n}" -le 3 ]
     do
 
         LINE="${Lines[$n]}"
-        
+
         FORCE_FORMAT="standard"
 
-        case "${LINE:0:1}" in 
+        case "${LINE:0:1}" in
             "+")
                 FORCE_FORMAT="pos"
                 LINE=${LINE:1:16}
@@ -108,18 +108,18 @@ function lcd_message () {
         fi
 
         oled +${DisplayLines[$n]} "${LINE}"
-        
+
 
         if [ ! -z "${LogLines}" ];
         then
             LogLines="${LogLines}\n"
         fi
         LogLines="${LogLines}${LINE}"
-        
+
         n=$(expr $n + 1)
     done
     oled s
-    
+
     # log
     if [ ! -z "${LogLines}" ];
     then

--- a/scripts/lib-log.sh
+++ b/scripts/lib-log.sh
@@ -26,16 +26,16 @@ function log_to_file () {
     MESSAGE=$1
 
     # Config
-    CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-#     CONFIG="${CONFIG_DIR}/config.cfg"
+    WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+#     CONFIG="${WORKING_DIR}/config.cfg"
 #     dos2unix "$CONFIG"
 #     source "$CONFIG"
 
-    LOGFILE="${CONFIG_DIR}/tmp/little-backup-box.log"
+    LOGFILE="${WORKING_DIR}/tmp/little-backup-box.log"
 
    if [ ! -f "${LOGFILE}" ];
     then
-        mkdir -p "${CONFIG_DIR}/tmp"
+        mkdir -p "${WORKING_DIR}/tmp"
         echo "" > "${LOGFILE}"
     fi
 

--- a/scripts/lib-log.sh
+++ b/scripts/lib-log.sh
@@ -24,20 +24,20 @@ function log_to_file () {
 
     # Arguments
     MESSAGE=$1
-    
+
     # Config
-    CONFIG_DIR=$(dirname "$0")
+    CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #     CONFIG="${CONFIG_DIR}/config.cfg"
 #     dos2unix "$CONFIG"
 #     source "$CONFIG"
 
     LOGFILE="${CONFIG_DIR}/tmp/little-backup-box.log"
-    
+
    if [ ! -f "${LOGFILE}" ];
     then
         mkdir -p "${CONFIG_DIR}/tmp"
         echo "" > "${LOGFILE}"
     fi
-    
+
     echo -e "$(date '+%H:%M:%S')\n${MESSAGE}\n\n$(cat ${LOGFILE})" > "${LOGFILE}"
 }

--- a/scripts/lib-mail.sh
+++ b/scripts/lib-mail.sh
@@ -26,19 +26,19 @@ function send_email () {
     SUBJECT="${1}"
     TEXT_PLAIN="${2}"
     TEXT_HTML="${3}"
-    
+
     # Config
-    CONFIG_DIR=$(dirname "$0")
+    CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     CONFIG="${CONFIG_DIR}/config.cfg"
     dos2unix "$CONFIG"
     source "$CONFIG"
 
     # Load LOG library
     . "${CONFIG_DIR}/lib-log.sh"
-    
+
     BOUNDARY="${RANDOM}${RANDOM}${RANDOM}"
     TEXT=""
-    
+
     #Mail-body
     if [ "${MAIL_HTML}" = true ] && [ ! -z "${TEXT_HTML}" ];
     then
@@ -46,7 +46,7 @@ function send_email () {
     else
         TEXT="\n\n$TEXT_PLAIN\n\n"
     fi
-    
+
     # Check internet connection and send
     # a notification if the NOTIFY option is enabled
     check=$(wget -q --spider http://google.com/)
@@ -57,6 +57,6 @@ function send_email () {
             --user $MAIL_USER':'$MAIL_PASSWORD \
             -T <(echo -e "From: ${MAIL_USER}\nTo: ${MAIL_TO}\nSubject: ${SUBJECT}\n${TEXT}")
     fi
-    
+
     log_to_file "Mail:\n${SUBJECT}\n${TEXT}"
 }

--- a/scripts/lib-mail.sh
+++ b/scripts/lib-mail.sh
@@ -28,13 +28,13 @@ function send_email () {
     TEXT_HTML="${3}"
 
     # Config
-    CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-    CONFIG="${CONFIG_DIR}/config.cfg"
+    WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    CONFIG="${WORKING_DIR}/config.cfg"
     dos2unix "$CONFIG"
     source "$CONFIG"
 
     # Load LOG library
-    . "${CONFIG_DIR}/lib-log.sh"
+    . "${WORKING_DIR}/lib-log.sh"
 
     BOUNDARY="${RANDOM}${RANDOM}${RANDOM}"
     TEXT=""

--- a/scripts/poweroff.sh
+++ b/scripts/poweroff.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
@@ -27,7 +27,7 @@ FILE_OLED_OLD="/root/oled_old.txt"
 FILE_LOG="/home/pi/little-backup-box/scripts/tmp/little-backup-box.log"
 FSCK_LOG="/home/pi/little-backup-box/scripts/tmp/fsck.log"
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 #Arguments
 MODE="$1"

--- a/scripts/poweroff.sh
+++ b/scripts/poweroff.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/restart-servers.sh
+++ b/scripts/restart-servers.sh
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 # Wait for a USB storage device (e.g., a USB flash drive)
 STORAGE=$(ls /dev/* | grep "$STORAGE_DEV" | cut -d"/" -f3)

--- a/scripts/restart-servers.sh
+++ b/scripts/restart-servers.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,14 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
 # Configuration
 FILE_OLED_OLD="/root/oled_old.txt"
-        
+
 # Load LCD library
 . "${CONFIG_DIR}/lib-lcd.sh"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
@@ -26,7 +26,7 @@ source "$CONFIG"
 FILE_OLED_OLD="/root/oled_old.txt"
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 ip=$(hostname -I | cut -d' ' -f1)
 

--- a/scripts/status-display.sh
+++ b/scripts/status-display.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 
@@ -38,7 +38,7 @@ else
 fi
 
 # Load LCD library
-. "${CONFIG_DIR}/lib-lcd.sh"
+. "${WORKING_DIR}/lib-lcd.sh"
 
 # Count of files in storage before backup starts
 FILES_COUNT_STORAGE_START=$(find $BACKUP_PATH -type f | wc -l)

--- a/scripts/status-display.sh
+++ b/scripts/status-display.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/status-webui.sh
+++ b/scripts/status-webui.sh
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CONFIG="${CONFIG_DIR}/config.cfg"
+WORKING_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="${WORKING_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"
 

--- a/scripts/status-webui.sh
+++ b/scripts/status-webui.sh
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #######################################################################
 
-CONFIG_DIR=$(dirname "$0")
+CONFIG_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="${CONFIG_DIR}/config.cfg"
 dos2unix "$CONFIG"
 source "$CONFIG"

--- a/scripts/tmp/little-backup-box.log
+++ b/scripts/tmp/little-backup-box.log
@@ -1,3 +1,9 @@
+23:18:36
+Destination: external
+
+23:18:36
+Source: storage
+
 Destination: external
 Source: storage
 -----------

--- a/scripts/tmp/little-backup-box.log
+++ b/scripts/tmp/little-backup-box.log
@@ -1,9 +1,0 @@
-23:18:36
-Destination: external
-
-23:18:36
-Source: storage
-
-Destination: external
-Source: storage
------------


### PR DESCRIPTION
Rename variable CONFIG_DIR to WORKING_DIR, because it is used for much more than finding config.cfg.
Replace method to find WORKING_DIR. The result of this one is independent of the path, used in the command-line to call the script (e.g. "./backup.sh" "/home/pi/little-backup-box/scripts/backup.sh" results always in "/home/pi/little-backup-box/scripts").