### PR TITLE
Remove user-specific paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Little Backup Box supports four backup modes:
 - **Source to external** Automatically backs up the contents of a source device (e.g., a storage card) to an external storage device.
 - **Source to internal** Automatically backs up the contents of a source device to the internal system storage.
 - **Camera to external** Transfers photos, RAW files, and videos from the connected camera to an external storage device.
-- **Camera to internal** Transfers photos, RAW files, and videos from the connected camera. The transferred files are saved in the _/home/pi/BACKUP/[CAMERA MODEL]_ directory on the system storage device. **Important** Make sure that the camera is set to the MTP USB connection mode.
+- **Camera to internal** Transfers photos, RAW files, and videos from the connected camera. The transferred files are saved in the _/home/$USER/BACKUP/[CAMERA MODEL]_ directory on the system storage device. **Important** Make sure that the camera is set to the MTP USB connection mode.
 
 During the installation, choose the desired mode from the selection dialog.
 

--- a/install-little-backup-box.sh
+++ b/install-little-backup-box.sh
@@ -166,7 +166,7 @@ sudo sh -c "echo 'panic action = /usr/share/samba/panic-action %d' >> /etc/samba
 sudo sh -c "echo '### Authentication ###' >> /etc/samba/smb.conf"
 sudo sh -c "echo 'security = user' >> /etc/samba/smb.conf"
 sudo sh -c "echo 'map to guest = Bad User' >> /etc/samba/smb.conf"
-sudo sh -c "echo 'guest account = pi' >> /etc/samba/smb.conf"
+sudo sh -c "echo 'guest account = $USER' >> /etc/samba/smb.conf"
 sudo sh -c "echo '### Share Definitions ###' >> /etc/samba/smb.conf"
 sudo sh -c "echo '[little-backup-box]' >> /etc/samba/smb.conf"
 sudo sh -c "echo 'comment = Little Backup Box /media/storage' >> /etc/samba/smb.conf"

--- a/scripts/index.php
+++ b/scripts/index.php
@@ -76,39 +76,39 @@ $theme = "dark";
 		</details>
 	</div>
 	<?php
-	exec("mkdir -p /home/pi/little-backup-box/scripts/tmp");
-	exec("echo '' > /home/pi/little-backup-box/scripts/tmp/little-backup-box.log}");
+	exec("mkdir -p tmp");
+	exec("echo '' > tmp/little-backup-box.log}");
 
 	if (isset($_POST['backup_storage_external'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/backup.sh storage external > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./backup.sh storage external > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::backup_storage_external_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['backup_storage_internal'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/backup.sh storage internal > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./backup.sh storage internal > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::backup_storage_internal_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['backup_camera_external'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/backup.sh camera external > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./backup.sh camera external > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::backup_camera_external_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['backup_camera_internal'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/backup.sh camera internal > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./backup.sh camera internal > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::backup_camera_internal_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['iosbackup'])) {
-		shell_exec('/home/pi/little-backup-box/scripts/ios-backup.sh > /dev/null 2>&1 & echo $!');
+		shell_exec('./ios-backup.sh > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::iosbackup_m . '")';
 		echo "</script>";
@@ -123,25 +123,25 @@ $theme = "dark";
 		echo "<script>";
 		echo 'alert("' . L::shutdown_m . '")';
 		echo "</script>";
-		shell_exec('sudo /home/pi/little-backup-box/scripts/poweroff.sh force');
+		shell_exec('sudo ./poweroff.sh force');
 	}
 	if (isset($_POST['custom1'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/custom1.sh > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./custom1.sh > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::custom1_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['custom2'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/custom2.sh > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo ./custom2.sh > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::custom2_m . '")';
 		echo "</script>";
 	}
 	if (isset($_POST['custom3'])) {
 		shell_exec('sudo pkill -f backup*');
-		shell_exec('sudo /home/pi/little-backup-box/scripts/custom3.sh > /dev/null 2>&1 & echo $!');
+		shell_exec('sudo .//custom3.sh > /dev/null 2>&1 & echo $!');
 		echo "<script>";
 		echo 'alert("' . L::custom3_m . '")';
 		echo "</script>";

--- a/scripts/poweroff.sh
+++ b/scripts/poweroff.sh
@@ -24,8 +24,8 @@ source "$CONFIG"
 
 # Configuration
 FILE_OLED_OLD="/root/oled_old.txt"
-FILE_LOG="/home/pi/little-backup-box/scripts/tmp/little-backup-box.log"
-FSCK_LOG="/home/pi/little-backup-box/scripts/tmp/fsck.log"
+FILE_LOG="tmp/little-backup-box.log"
+FSCK_LOG="tmp/fsck.log"
 # Load LCD library
 . "${WORKING_DIR}/lib-lcd.sh"
 

--- a/scripts/status-display.sh
+++ b/scripts/status-display.sh
@@ -32,7 +32,7 @@ fi
 
 if [ -z $2 ];
 then
-    BACKUP_PATH="/home/pi/BACKUP"
+    BACKUP_PATH="$BAK_DIR"
 else
     BACKUP_PATH=$2
 fi


### PR DESCRIPTION
Several scripts used user-specific paths, such as _/home/pi/little-backup-box/scripts/backup.sh_ To make Little Backup Box work on other distributions that do not the `pi` user account, I removed all the user-specific paths.